### PR TITLE
feat: Add `hasPresentKey` `hasDefinedKey` `hasKey` functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/node": "^12.12.17",
     "jest": "^24.9.0",
     "ts-jest": "^24.2.0",
-    "typescript": "^3.7.3"
+    "typescript": "^3.9.7"
   },
   "runkitExampleFilename": "runkit-example.js"
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -4,8 +4,6 @@ import {
   isDefined,
   isFilled,
   hasPresentKey,
-  hasDefinedKey,
-  hasKey,
   hasValueAtKey,
 } from ".";
 
@@ -128,32 +126,6 @@ describe("Functions", () => {
     });
   });
 
-  describe("hasKey", () => {
-    it("returns true only for objects that have the given key", () => {
-      expect(hasKey("data")({ data: undefined })).toEqual(true);
-      expect(hasKey("data")({ data: null })).toEqual(true);
-      expect(hasKey("data")({ data: "" })).toEqual(true);
-      expect(hasKey("data")({ data: "hello" })).toEqual(true);
-
-      const items: Array<{ data?: string | null }> = [
-        {},
-        { data: undefined },
-        { data: null },
-        { data: "" },
-        { data: "hello" },
-      ];
-      const result: Array<{
-        data: string | null | undefined;
-      }> = items.filter(hasKey("data"));
-      expect(result).toEqual([
-        { data: undefined },
-        { data: null },
-        { data: "" },
-        { data: "hello" },
-      ]);
-    });
-  });
-
   describe("hasPresentKey", () => {
     it("returns true only for objects that have a defined non-null value at the given key", () => {
       expect(hasPresentKey("data")({ data: undefined })).toEqual(false);
@@ -172,27 +144,6 @@ describe("Functions", () => {
         hasPresentKey("data")
       );
       expect(result).toEqual([{ data: "" }, { data: "hello" }]);
-    });
-  });
-
-  describe("hasDefinedKey", () => {
-    it("returns true only for objects that have a defined value at the given key", () => {
-      expect(hasDefinedKey("data")({ data: undefined })).toEqual(false);
-      expect(hasDefinedKey("data")({ data: null })).toEqual(true);
-      expect(hasDefinedKey("data")({ data: "" })).toEqual(true);
-      expect(hasDefinedKey("data")({ data: "hello" })).toEqual(true);
-
-      const items: Array<{ data?: string | null }> = [
-        {},
-        { data: undefined },
-        { data: null },
-        { data: "" },
-        { data: "hello" },
-      ];
-      const result: Array<{ data: string | null }> = items.filter(
-        hasDefinedKey("data")
-      );
-      expect(result).toEqual([{ data: null }, { data: "" }, { data: "hello" }]);
     });
   });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -140,9 +140,24 @@ describe("Functions", () => {
         { data: "" },
         { data: "hello" },
       ];
-      const result: Array<{ data: string }> = items.filter(
-        hasPresentKey("data")
-      );
+      const result = items.filter(hasPresentKey("data"));
+      expect(result).toEqual([{ data: "" }, { data: "hello" }]);
+    });
+
+    it("can be used on non-null properties", () => {
+      const items: Array<{ data?: string | undefined }> = [
+        {},
+        { data: undefined },
+        { data: "" },
+        { data: "hello" },
+      ];
+      const result = items.filter(hasPresentKey("data"));
+      expect(result).toEqual([{ data: "" }, { data: "hello" }]);
+    });
+
+    it("can be used on non-null, non-undefined properties", () => {
+      const items: Array<{ data: string }> = [{ data: "" }, { data: "hello" }];
+      const result = items.filter(hasPresentKey("data"));
       expect(result).toEqual([{ data: "" }, { data: "hello" }]);
     });
   });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,116 +1,242 @@
-import 'jest';
-import { isPresent, isDefined, isFilled } from '.';
+import "jest";
+import {
+  isPresent,
+  isDefined,
+  isFilled,
+  hasPresentKey,
+  hasDefinedKey,
+  hasKey,
+  hasValueAtKey,
+} from ".";
 
 type TestData = {
   data: string;
 };
 
-describe('Functions', () => {
-  describe('isPresent', () => {
-    it('should return true on present', () => {
-      expect(isPresent<TestData>({ data: 'hello world' })).toBeTruthy();
+describe("Functions", () => {
+  describe("isPresent", () => {
+    it("should return true on present", () => {
+      expect(
+        isPresent<TestData>({ data: "hello world" })
+      ).toBeTruthy();
     });
 
-    it('should return false on undefined', () => {
+    it("should return false on undefined", () => {
       expect(isPresent<TestData>(undefined)).toBeFalsy();
     });
 
-    it('should return false on null', () => {
+    it("should return false on null", () => {
       expect(isPresent<TestData>(null)).toBeFalsy();
     });
 
-    it('should return false on void with undefined', () => {
+    it("should return false on void with undefined", () => {
       const voidVal: void = undefined;
       expect(isPresent<TestData>(voidVal)).toBeFalsy();
     });
 
-    it('should filter out only present values from an array', () => {
+    it("should filter out only present values from an array", () => {
       const results: Array<TestData | undefined | null> = [
-        { data: 'hello' },
+        { data: "hello" },
         null,
-        { data: 'world' },
+        { data: "world" },
         undefined,
-        { data: 'wow'}
+        { data: "wow" },
       ];
 
       const presentResults: Array<TestData> = results.filter(isPresent);
 
       expect(presentResults).toEqual([
-        { data: 'hello' },
-        { data: 'world' },
-        { data: 'wow'}
-      ])
+        { data: "hello" },
+        { data: "world" },
+        { data: "wow" },
+      ]);
     });
   });
 
-  describe('isDefined', () => {
-    it('should return true on defined', () => {
-      expect(isDefined<TestData>({ data: 'hello world' })).toBeTruthy();
+  describe("isDefined", () => {
+    it("should return true on defined", () => {
+      expect(
+        isDefined<TestData>({ data: "hello world" })
+      ).toBeTruthy();
     });
 
-    it('should return false on undefined', () => {
+    it("should return false on undefined", () => {
       expect(isDefined<TestData>(undefined)).toBeFalsy();
     });
 
-    it('does not typecheck', () => {
+    it("does not typecheck", () => {
       const results: Array<TestData | undefined> = [
-        { data: 'hello' },
-        { data: 'world' },
+        { data: "hello" },
+        { data: "world" },
         undefined,
-        { data: 'wow'}
+        { data: "wow" },
       ];
 
       const presentResults: Array<TestData> = results.filter(isDefined);
 
       expect(presentResults).toEqual([
-        { data: 'hello' },
-        { data: 'world' },
-        { data: 'wow'}
-      ])
+        { data: "hello" },
+        { data: "world" },
+        { data: "wow" },
+      ]);
     });
 
-    it('should filter out only present values from an array', () => {
+    it("should filter out only present values from an array", () => {
       const results: Array<TestData | undefined> = [
-        { data: 'hello' },
-        { data: 'world' },
+        { data: "hello" },
+        { data: "world" },
         undefined,
-        { data: 'wow'}
+        { data: "wow" },
       ];
 
       const presentResults: Array<TestData> = results.filter(isDefined);
 
       expect(presentResults).toEqual([
-        { data: 'hello' },
-        { data: 'world' },
-        { data: 'wow'}
-      ])
+        { data: "hello" },
+        { data: "world" },
+        { data: "wow" },
+      ]);
     });
   });
 
-  describe('isFilled', () => {
-    it('should return true on defined', () => {
-      expect(isFilled<TestData>({ data: 'hello world' })).toBeTruthy();
+  describe("isFilled", () => {
+    it("should return true on defined", () => {
+      expect(
+        isFilled<TestData>({ data: "hello world" })
+      ).toBeTruthy();
     });
 
-    it('should return false on null', () => {
+    it("should return false on null", () => {
       expect(isFilled<TestData>(null)).toBeFalsy();
     });
 
-    it('should filter out only present values from an array', () => {
+    it("should filter out only present values from an array", () => {
       const results: Array<TestData | null> = [
-        { data: 'hello' },
+        { data: "hello" },
         null,
-        { data: 'world' },
-        { data: 'wow'}
+        { data: "world" },
+        { data: "wow" },
       ];
 
       const presentResults: Array<TestData> = results.filter(isFilled);
 
       expect(presentResults).toEqual([
-        { data: 'hello' },
-        { data: 'world' },
-        { data: 'wow'}
-      ])
+        { data: "hello" },
+        { data: "world" },
+        { data: "wow" },
+      ]);
+    });
+  });
+
+  describe("hasKey", () => {
+    it("returns true only for objects that have the given key", () => {
+      expect(hasKey("data")({ data: undefined })).toEqual(true);
+      expect(hasKey("data")({ data: null })).toEqual(true);
+      expect(hasKey("data")({ data: "" })).toEqual(true);
+      expect(hasKey("data")({ data: "hello" })).toEqual(true);
+
+      const items: Array<{ data?: string | null }> = [
+        {},
+        { data: undefined },
+        { data: null },
+        { data: "" },
+        { data: "hello" },
+      ];
+      const result: Array<{
+        data: string | null | undefined;
+      }> = items.filter(hasKey("data"));
+      expect(result).toEqual([
+        { data: undefined },
+        { data: null },
+        { data: "" },
+        { data: "hello" },
+      ]);
+    });
+  });
+
+  describe("hasPresentKey", () => {
+    it("returns true only for objects that have a defined non-null value at the given key", () => {
+      expect(hasPresentKey("data")({ data: undefined })).toEqual(false);
+      expect(hasPresentKey("data")({ data: null })).toEqual(false);
+      expect(hasPresentKey("data")({ data: "" })).toEqual(true);
+      expect(hasPresentKey("data")({ data: "hello" })).toEqual(true);
+
+      const items: Array<{ data?: string | null | undefined }> = [
+        {},
+        { data: undefined },
+        { data: null },
+        { data: "" },
+        { data: "hello" },
+      ];
+      const result: Array<{ data: string }> = items.filter(
+        hasPresentKey("data")
+      );
+      expect(result).toEqual([{ data: "" }, { data: "hello" }]);
+    });
+  });
+
+  describe("hasDefinedKey", () => {
+    it("returns true only for objects that have a defined value at the given key", () => {
+      expect(hasDefinedKey("data")({ data: undefined })).toEqual(false);
+      expect(hasDefinedKey("data")({ data: null })).toEqual(true);
+      expect(hasDefinedKey("data")({ data: "" })).toEqual(true);
+      expect(hasDefinedKey("data")({ data: "hello" })).toEqual(true);
+
+      const items: Array<{ data?: string | null }> = [
+        {},
+        { data: undefined },
+        { data: null },
+        { data: "" },
+        { data: "hello" },
+      ];
+      const result: Array<{ data: string | null }> = items.filter(
+        hasDefinedKey("data")
+      );
+      expect(result).toEqual([{ data: null }, { data: "" }, { data: "hello" }]);
+    });
+  });
+
+  describe("hasValueAtKey", () => {
+    it("returns true only for objects that have a defined value at the given key", () => {
+      expect(hasValueAtKey("data", "a")({ data: undefined })).toEqual(false);
+      expect(hasValueAtKey("data", "a")({ data: null })).toEqual(false);
+      expect(hasValueAtKey("data", "a")({ data: "a" })).toEqual(true);
+      expect(hasValueAtKey("data", "a")({ data: "b" })).toEqual(false);
+
+      const items: Array<{ data: "a" | "b" | null | undefined }> = [
+        { data: undefined },
+        { data: null },
+        { data: "a" },
+        { data: "b" },
+      ];
+      const result: Array<{ data: "a" }> = items.filter(
+        hasValueAtKey("data", "a" as const)
+      );
+      expect(result).toEqual([{ data: "a" }]);
+
+      const fruits: Array<
+        | {
+            type: "apple";
+            isApple: true;
+          }
+        | {
+            type: "banana";
+            isBanana: true;
+          }
+      > = [
+        { type: "apple", isApple: true },
+        { type: "banana", isBanana: true },
+      ];
+      const fruitsResult: Array<{
+        type: "apple";
+        isApple: true;
+      }> = fruits.filter(hasValueAtKey("type", "apple" as const));
+      expect(fruitsResult).toEqual([
+        {
+          type: "apple",
+          isApple: true,
+        },
+      ]);
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ export function isFilled<T>(t: T | null): t is T {
 
 /**
  * Returns a function that can be used to filter down objects
- * to the ones that have a defined non-null value under a key `k`.
+ * to the ones that have a defined non-null value under the key `k`.
  *
  * @example
  * ```ts
@@ -40,12 +40,17 @@ export function hasPresentKey<K extends string | number | symbol>(k: K) {
  *
  * @example
  * ```ts
- * const imageFiles = files.filter(file => file.type === "image");
- * files[0].type // In this case, TS might still treat this as string/undefined/null
+ * type File = { type: "image", imageUrl: string } | { type: "pdf", pdfUrl: string };
+ * const files: File[] = [];
  *
- * const filesWithUrl = files.filter(hasValueKey("type", "image" as "image"));
- * files[0].type // TS will know that this is "image"
- * Note the cast is necessary otherwise TS will only know that type is a string
+ * const imageFiles = files.filter(file => file.type === "image");
+ * files[0].type // In this case, TS will still treat it  as `"image" | "pdf"`
+ *
+ * const filesWithUrl = files.filter(hasValueKey("type", "image" as const));
+ * files[0].type // TS will now know that this is "image"
+ * files[0].imageUrl // TS will know this is present, because already it excluded the other union members.
+ *
+ * Note: the cast `as const` is necessary, otherwise TS will only know that type is a string.
  * ```
  *
  * See https://github.com/microsoft/TypeScript/issues/16069

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,85 @@ export function isDefined<T>(t: T | undefined): t is T {
 export function isFilled<T>(t: T | null): t is T {
   return t !== null;
 }
+
+/**
+ * Returns a function that can be used to filter down objects
+ * to the ones that have a key `k`.
+ */
+export function hasKey<K extends string | number | symbol>(k: K) {
+  return function <T, V>(a: T & { [k in K]?: V }): a is T & { [k in K]: V } {
+    return k in a;
+  };
+}
+
+/**
+ * Returns a function that can be used to filter down objects
+ * to the ones that have a defined non-null value under a key `k`.
+ *
+ * @example
+ * ```ts
+ * const filesWithUrl = files.filter(file => file.url);
+ * files[0].url // In this case, TS might still treat this as undefined/null
+ *
+ * const filesWithUrl = files.filter(hasPresentKey("url"));
+ * files[0].url // TS will know that this is present
+ * ```
+ *
+ * See https://github.com/microsoft/TypeScript/issues/16069
+ * why is that useful.
+ */
+export function hasPresentKey<K extends string | number | symbol>(k: K) {
+  return function <T, V>(
+    a: T & { [k in K]?: V | null }
+  ): a is T & { [k in K]: V } {
+    return a[k] !== undefined && a[k] !== null;
+  };
+}
+
+/**
+ * Returns a function that can be used to filter down objects
+ * to the ones that have a defined value under a key `k`.
+ *
+ * @example
+ * ```ts
+ * const filesWithUrl = files.filter(file => file.url);
+ * files[0].url // In this case, TS might still treat this as undefined/null
+ *
+ * const filesWithUrl = files.filter(hasDefinedKey("url"));
+ * files[0].url // TS will know that this is defined
+ * ```
+ *
+ * See https://github.com/microsoft/TypeScript/issues/16069
+ * why is that useful.
+ */
+export function hasDefinedKey<K extends string | number | symbol>(k: K) {
+  return function <T, V>(a: T & { [k in K]?: V }): a is T & { [k in K]: V } {
+    return a[k] !== undefined;
+  };
+}
+
+/**
+ * Returns a function that can be used to filter down objects
+ * to the ones that have a specific value V under a key `k`.
+ *
+ * @example
+ * ```ts
+ * const imageFiles = files.filter(file => file.type === "image");
+ * files[0].type // In this case, TS might still treat this as string/undefined/null
+ *
+ * const filesWithUrl = files.filter(hasValueKey("type", "image" as "image"));
+ * files[0].type // TS will know that this is "image"
+ * Note the cast is necessary otherwise TS will only know that type is a string
+ * ```
+ *
+ * See https://github.com/microsoft/TypeScript/issues/16069
+ * why is that useful.
+ */
+export function hasValueAtKey<K extends string | number | symbol, V>(
+  k: K,
+  v: V
+) {
+  return function <T>(a: T & { [k in K]: any }): a is T & { [k in K]: V } {
+    return a[k] === v;
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,16 +12,6 @@ export function isFilled<T>(t: T | null): t is T {
 
 /**
  * Returns a function that can be used to filter down objects
- * to the ones that have a key `k`.
- */
-export function hasKey<K extends string | number | symbol>(k: K) {
-  return function <T, V>(a: T & { [k in K]?: V }): a is T & { [k in K]: V } {
-    return k in a;
-  };
-}
-
-/**
- * Returns a function that can be used to filter down objects
  * to the ones that have a defined non-null value under a key `k`.
  *
  * @example
@@ -41,28 +31,6 @@ export function hasPresentKey<K extends string | number | symbol>(k: K) {
     a: T & { [k in K]?: V | null }
   ): a is T & { [k in K]: V } {
     return a[k] !== undefined && a[k] !== null;
-  };
-}
-
-/**
- * Returns a function that can be used to filter down objects
- * to the ones that have a defined value under a key `k`.
- *
- * @example
- * ```ts
- * const filesWithUrl = files.filter(file => file.url);
- * files[0].url // In this case, TS might still treat this as undefined/null
- *
- * const filesWithUrl = files.filter(hasDefinedKey("url"));
- * files[0].url // TS will know that this is defined
- * ```
- *
- * See https://github.com/microsoft/TypeScript/issues/16069
- * why is that useful.
- */
-export function hasDefinedKey<K extends string | number | symbol>(k: K) {
-  return function <T, V>(a: T & { [k in K]?: V }): a is T & { [k in K]: V } {
-    return a[k] !== undefined;
   };
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3375,10 +3375,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@^3.7.3:
-  version "3.7.3"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
-  integrity sha1-s2hAZooWRYpwJbnqv60Rtmq4XGk=
+typescript@^3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 uglify-js@^3.1.4:
   version "3.7.2"


### PR DESCRIPTION
Adds `hasKey` `hasDefinedKey` `hasPresentKey` `hasValueAtKey` functions.

~~Very weirdly though, those functions work in our project (which uses TS 3.9.7), but in here, they throw errors while ts-jest tries to compile the test file. (See screenshot below.) I tried upgrading this library TS version to 3.9 but it didn't help. I can't find any solution to it.~~

~~For now I'm raising a PR just in case somebody would like to play around with it. Maybe you'll find a fix to it.~~

**EDIT:** No longer relevant, all passes good now, I've fixed the TS errors. Tested on TS 3.7.4 and 4.0.5 .